### PR TITLE
fixed right margin in the footer

### DIFF
--- a/beamerthemetudo.sty
+++ b/beamerthemetudo.sty
@@ -93,7 +93,7 @@
 \newlength{\footercenterwidth}
 \setlength{\footercenterwidth}{0.6\paperwidth}
 \newlength{\footerrightwidth}
-\setlength{\footerrightwidth}{0.2\paperwidth}
+\setlength{\footerrightwidth}{0.2\paperwidth-\beamer@rightmargin} % hotfix for no right margin in footer
 
 \setbeamertemplate{footline}
 {%
@@ -130,7 +130,7 @@
       wd=\footerrightwidth,
       ht=4ex,
       dp=10pt,
-      rightskip=\beamer@rightmargin,
+      %rightskip=\beamer@rightmargin,
     ]{frame}%
       \raggedleft%
       \usebeamerfont{framenumber}\insertframenumber%


### PR DESCRIPTION
Somehow, the `rightskip=\beamer@rightmargin` does not work any more for the footer. Without this fix, there is no space between the right edge of the frame and the frame number in the bottom right corner. I created a workaround by making the beamercolorbox smaller instead of using the rightskip.

Before the fix:
![grafik](https://user-images.githubusercontent.com/55792255/180408424-7995c6ce-5425-4333-8cae-d326439d2200.png)

After the fix:
![grafik](https://user-images.githubusercontent.com/55792255/180408638-c37ca5e1-ff20-48bf-9e46-0445a1eaba20.png)
