### PR TITLE
Added command to add institute logo to beamer header

### DIFF
--- a/beamerthemetudo.sty
+++ b/beamerthemetudo.sty
@@ -18,6 +18,9 @@
 \setbeamersize{text margin left=15pt, text margin right=15pt}
 \usefonttheme{professionalfonts}
 
+% Adds an institute logo to the header
+\newcommand*\theinstitutelogo{}
+\newcommand*\institutelogo[1]{\renewcommand\theinstitutelogo{#1}}
 
 % If xelatex or lualatex, use fontspec to set fonts
 \newif\if@fontspec\@fontspecfalse
@@ -80,7 +83,11 @@
     leftskip=1em,
     rightskip=\beamer@rightmargin,
   ]{headline}%
-  \usebeamerfont{institute in head/foot}\hfill\insertshortinstitute[respectlinebreaks]
+    \ifx\theinstitutelogo\empty
+      \usebeamerfont{institute in head/foot}\hfill\insertshortinstitute[respectlinebreaks]
+    \else%
+      \hfill\theinstitutelogo
+    \fi%
   \end{beamercolorbox}%
   \vskip2ex%
   \ifnum\insertframenumber=1%

--- a/example.tex
+++ b/example.tex
@@ -38,6 +38,8 @@
 \institute[Kurzform Lehrstuhl]{Names des Lehrstuhls \\  Name der Fakultät}
 \titlegraphic{\includegraphics[width=0.7\textwidth]{images/tudo-title-2.jpg}}
 
+%% Add your institute logo to the header instead of short form of the institute name, e.g.
+%\institutelogo{\includegraphics[height=\headerheight]{<path_to_institute_logo>}}
 
 \begin{document}
 


### PR DESCRIPTION
This adds a `\institutelogo{}` command that allows to add a logo instead of the short name of the institute to the right side of the header. If not used, the theme will print the institute name as before.

The general idea is to make the theme more accessible, i.e. not having to change `beamertheme.sty` to have one or more logos in the header.